### PR TITLE
Remove down-propagation of `notIn` constraints

### DIFF
--- a/app/src/main/scala/examples.scala
+++ b/app/src/main/scala/examples.scala
@@ -86,5 +86,39 @@ def parallelDimensionRemovalExample =
 
   inferTypes(schema, typing)
 
+def susExample =
+  val dim_a = Dim("a")
+  val (add_dim_a_schema, add_dim_a_ty) = addDimSchema(dim_a)
+  val (remove_dim_a_schema, remove_dim_a_ty) = removeDimSchema(dim_a)
 
+  val add_dim_a_block = add_dim_a_schema.instantiate
+  val remove_dim_a_block = remove_dim_a_schema.instantiate
 
+  val x = DimSetVar("X")
+  val y0 = DimSetVar("Y_0")
+  val y1 = DimSetVar("Y_1")
+
+  val v0 = add_dim_a_block.freshMapping(add_dim_a_block.schema.inVertices.head)
+  val v1 = add_dim_a_block.freshMapping(add_dim_a_block.schema.outVertices.head)
+
+  val v2 = remove_dim_a_block.freshMapping(remove_dim_a_block.schema.inVertices.head)
+  val v3 = remove_dim_a_block.freshMapping(remove_dim_a_block.schema.outVertices.head)
+
+  val schema = BlockSchema(
+    List(x),
+    List(y0, y1),
+    Set(add_dim_a_block, remove_dim_a_block),
+    Set(
+      x -> v0,
+      v1 -> y0,
+      x -> v2,
+      v3 -> y1,
+    )
+  )
+
+  val typing = collection.mutable.Map(
+    add_dim_a_schema -> add_dim_a_ty,
+    remove_dim_a_schema -> remove_dim_a_ty,
+  )
+
+  inferTypes(schema, typing)

--- a/app/src/main/scala/examples.scala
+++ b/app/src/main/scala/examples.scala
@@ -86,6 +86,7 @@ def parallelDimensionRemovalExample =
 
   inferTypes(schema, typing)
 
+@main
 def susExample =
   val dim_a = Dim("a")
   val (add_dim_a_schema, add_dim_a_ty) = addDimSchema(dim_a)

--- a/app/src/main/scala/examples.scala
+++ b/app/src/main/scala/examples.scala
@@ -122,3 +122,138 @@ def susExample =
   )
 
   inferTypes(schema, typing)
+
+def funnySchema =
+  val dim_a = Dim("a")
+  val dim_b = Dim("b")
+
+  val x0 = DimSetVar("X_0")
+  val x1 = DimSetVar("X_1")
+  val y0 = DimSetVar("Y_0")
+  val y1 = DimSetVar("Y_1")
+
+  val (add_dim_a_schema, add_dim_a_ty) = addDimSchema(dim_a)
+  val add_dim_a_block = add_dim_a_schema.instantiate
+
+  val (remove_dim_b_schema, remove_dim_b_ty) = removeDimSchema(dim_b)
+  val remove_dim_b_block = remove_dim_b_schema.instantiate
+
+  val v0 = add_dim_a_block.freshMapping(add_dim_a_block.schema.inVertices.head)
+  val v1 = add_dim_a_block.freshMapping(add_dim_a_block.schema.outVertices.head)
+
+  val v2 = remove_dim_b_block.freshMapping(remove_dim_b_block.schema.inVertices.head)
+  val v3 = remove_dim_b_block.freshMapping(remove_dim_b_block.schema.outVertices.head)
+
+  val schema = BlockSchema(
+    List(x0, x1),
+    List(y0, y1),
+    Set(add_dim_a_block, remove_dim_b_block),
+    Set(
+      x0 -> v0,
+      x1 -> v2,
+      v1 -> y0,
+      v3 -> y1,
+    ),
+  )
+
+  val typing = collection.mutable.Map(
+    add_dim_a_schema -> add_dim_a_ty,
+    remove_dim_b_schema -> remove_dim_b_ty,
+  )
+
+  (schema, typing)
+
+@main
+def funnySchemaExample =
+  val (schema, typing) = funnySchema
+  inferTypes(schema, typing)
+
+@main
+def funnySchemaSequential =
+  val (funny_schema, funny_typing) = funnySchema
+
+  val funny_block_1 = funny_schema.instantiate
+  val funny_block_2 = funny_schema.instantiate
+
+  val x0 = DimSetVar("X_0")
+  val x1 = DimSetVar("X_1")
+  val y0 = DimSetVar("Y_0")
+  val y1 = DimSetVar("Y_1")
+
+
+  val v0 = funny_block_1.freshMapping(funny_block_1.schema.inVertices.head)
+  val v1 = funny_block_1.freshMapping(funny_block_1.schema.inVertices(1))
+  val v2 = funny_block_1.freshMapping(funny_block_1.schema.outVertices.head)
+  val v3 = funny_block_1.freshMapping(funny_block_1.schema.outVertices(1))
+
+  val v4 = funny_block_2.freshMapping(funny_block_2.schema.inVertices.head)
+  val v5 = funny_block_2.freshMapping(funny_block_2.schema.inVertices(1))
+  val v6 = funny_block_2.freshMapping(funny_block_2.schema.outVertices.head)
+  val v7 = funny_block_2.freshMapping(funny_block_2.schema.outVertices(1))
+
+  val schema = BlockSchema(
+    List(x0, x1),
+    List(y0, y1),
+    Set(funny_block_1, funny_block_2),
+    Set(
+      x0 -> v0,
+      x1 -> v1,
+      v2 -> v5,
+      v3 -> v4,
+      v6 -> y0,
+      v7 -> y1,
+    ),
+  )
+
+  inferTypes(schema, funny_typing)
+
+
+@main
+def funnySchemaExampleParallel =
+  val (funny_schema, funny_typing) = funnySchema
+  val (union_schema, union_ty) = unionSchema(4)
+
+  val funny_block_1 = funny_schema.instantiate
+  val funny_block_2 = funny_schema.instantiate
+  val union_block = union_schema.instantiate
+
+  val x0 = DimSetVar("X_0")
+  val x1 = DimSetVar("X_1")
+  val y = DimSetVar("Y")
+
+  val v0 = funny_block_1.freshMapping(funny_block_1.schema.inVertices.head)
+  val v1 = funny_block_1.freshMapping(funny_block_1.schema.inVertices(1))
+  val v2 = funny_block_1.freshMapping(funny_block_1.schema.outVertices.head)
+  val v3 = funny_block_1.freshMapping(funny_block_1.schema.outVertices(1))
+
+  val v4 = funny_block_2.freshMapping(funny_block_2.schema.inVertices.head)
+  val v5 = funny_block_2.freshMapping(funny_block_2.schema.inVertices(1))
+  val v6 = funny_block_2.freshMapping(funny_block_2.schema.outVertices.head)
+  val v7 = funny_block_2.freshMapping(funny_block_2.schema.outVertices(1))
+
+  val v8 = union_block.freshMapping(union_block.schema.inVertices.head)
+  val v9 = union_block.freshMapping(union_block.schema.inVertices(1))
+  val v10 = union_block.freshMapping(union_block.schema.inVertices(2))
+  val v11 = union_block.freshMapping(union_block.schema.inVertices(3))
+  val v12 = union_block.freshMapping(union_block.schema.outVertices.head)
+
+
+  val schema = BlockSchema(
+    List(x0, x1),
+    List(y),
+    Set(funny_block_1, funny_block_2, union_block),
+    Set(
+      x0 -> v0,
+      x0 -> v5,
+      x1 -> v1,
+      x1 -> v4,
+      v2 -> v8,
+      v3 -> v9,
+      v6 -> v10,
+      v7 -> v11,
+      v12 -> y,
+    ),
+  )
+
+  funny_typing.put(union_schema, union_ty)
+  inferTypes(schema, funny_typing)

--- a/app/src/main/scala/main.scala
+++ b/app/src/main/scala/main.scala
@@ -1,10 +1,12 @@
 package hocki.klocki
 
-import semantics.dims.DimSetVar
-
-import hocki.klocki.typing.Constraint.InducedBy
-
 @main
 def main(): Unit =
-  // chainedDimensionIntroductionsExample
+  println("--- CHAINED DIMENSION INTRODUCTION EXAMPLE ---")
+  chainedDimensionIntroductionsExample
+
+  println("--- PARALLEL DIMENSION INTRODUCTION EXAMPLE ---")
   parallelDimensionRemovalExample
+
+  println("--- SUS EXAMPLE ---")
+  susExample

--- a/app/src/main/scala/typing/Constraint.scala
+++ b/app/src/main/scala/typing/Constraint.scala
@@ -3,25 +3,26 @@ package typing
 
 import semantics.dims.{Dim, DimSetVar}
 
-import hocki.klocki.typing.Constraint.InducedBy
-
 enum Constraint:
+  case In(dim: Dim, dimSetVar: DimSetVar)
   case InUnion(dim: Dim, union: Set[DimSetVar])
   case NotIn(dim: Dim, dimSetVar: DimSetVar)
   case DependsOn(dim: Dim, filteredDimSetVar: FilteredDimSetVar)
   case InducedBy(induced: DimSetVar, inducers: Set[FilteredDimSetVar])
 
   override def toString: String = this match
+    case In(dim, dimSetVar) => s"$dim ∈ $dimSetVar"
     case InUnion(dim, union) => s"$dim ∈ U{${union.mkString(", ")}}"
     case NotIn(dim, dimSetVar) => s"$dim ∉ $dimSetVar"
     case DependsOn(dim, filteredDimSetVar) => s"$dim --> $filteredDimSetVar"
     case InducedBy(induced, inducers) => s"$induced <== ${inducers.mkString(", ")}"
 
   def map(mapping: Map[DimSetVar, DimSetVar]): Constraint = this match
+    case In(dim, dimSetVar) => In(dim, mapping(dimSetVar))
     case InUnion(dim, union) => InUnion(dim, union.map(mapping))
     case NotIn(dim, dimSetVar) => NotIn(dim, mapping(dimSetVar))
     case DependsOn(dim, filteredDimSetVar) => DependsOn(dim, filteredDimSetVar.map(mapping))
     case InducedBy(induced, inducers) => InducedBy(mapping(induced), inducers.map(_.map(mapping)))
-    
-extension (inducedBy: InducedBy)
+
+extension (inducedBy: Constraint.InducedBy)
   def inducerDimSetVars: Set[DimSetVar] = inducedBy.inducers.map(_.dimSetVar)

--- a/app/src/main/scala/typing/Constraint.scala
+++ b/app/src/main/scala/typing/Constraint.scala
@@ -15,7 +15,7 @@ enum Constraint:
     case InUnion(dim, union) => s"$dim ∈ U{${union.mkString(", ")}}"
     case NotIn(dim, dimSetVar) => s"$dim ∉ $dimSetVar"
     case DependsOn(dim, filteredDimSetVar) => s"$dim --> $filteredDimSetVar"
-    case InducedBy(induced, inducers) => s"$induced <== ${inducers.mkString(", ")}"
+    case InducedBy(induced, inducers) => s"$induced ⊇ ${inducers.mkString(", ")}"
 
   def map(mapping: Map[DimSetVar, DimSetVar]): Constraint = this match
     case In(dim, dimSetVar) => In(dim, mapping(dimSetVar))

--- a/app/src/main/scala/typing/basicTypes.scala
+++ b/app/src/main/scala/typing/basicTypes.scala
@@ -11,7 +11,7 @@ def addDimSchema(dim: Dim): (BlockSchema, BlockTy) =
   val y = schema.outVertices.head
   val constraints = Set(
     dim notIn x,
-    dim inUnion Set(y),
+    dim in y,
     dim dependsOn (x without Set(dim)),
     y inducedBy Set(x without Set(dim)),
   )

--- a/app/src/main/scala/typing/constraints.scala
+++ b/app/src/main/scala/typing/constraints.scala
@@ -4,6 +4,7 @@ package typing
 import semantics.dims.{Dim, DimSetVar}
 
 extension (dim: Dim)
+  infix def in(dimSetVar: DimSetVar): Constraint.In = Constraint.In(dim, dimSetVar)
   infix def inUnion(union: Set[DimSetVar]): Constraint.InUnion = Constraint.InUnion(dim, union)
   infix def notIn(dimSetVar: DimSetVar): Constraint.NotIn = Constraint.NotIn(dim, dimSetVar)
   infix def dependsOn(dimSetVar: FilteredDimSetVar): Constraint.DependsOn = Constraint.DependsOn(dim, dimSetVar)


### PR DESCRIPTION
The following constraints are propagated only one way:
- `in` - down
- `notIn` - up
- `inUnion` - up
